### PR TITLE
Add Deploy to PandaStack button

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <a style='font-size: 1.5rem;' href='https://gpt-assist-teal.vercel.app/role'>Visit Demo Site</a>
 
 [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FeaasyIce%2Fgpt_assistant&project-name=gpt-assistant&demo-url=https%3A%2F%2Fai-assist-teal.vercel.app)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=miniizinc/gpt_assistant&type=static&buildCmd=npm+run+build&outputDir=dist)
 
 </p>
 <p align='center'>
@@ -45,6 +46,7 @@
 ## Delpoy
 
 -   Vercel: [![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2FeaasyIce%2Fgpt_assistant&project-name=gpt-assistant&demo-url=https%3A%2F%2Fai-assist-teal.vercel.app)
+[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=miniizinc/gpt_assistant&type=static&buildCmd=npm+run+build&outputDir=dist)
 -   Deploy locally
     - run the following command in your local environment:
         ```


### PR DESCRIPTION
<img src="https://pandastack.io/logo.png" alt="PandaStack" height="40"/>

## Add Deploy to PandaStack button

This PR adds a **[Deploy to PandaStack](https://pandastack.io)** button alongside the existing Vercel button.

**[PandaStack](https://pandastack.io)** is a cloud deployment platform — supports static sites, containerized apps, databases, cronjobs, and more. A great alternative hosting option for your users.

### What this adds
```
[![Deploy to PandaStack](https://dashboard.pandastack.io/deploy-button.svg)](https://dashboard.pandastack.io/deploy?repo=miniizinc/gpt_assistant)
```

Happy to adjust build settings or output directory if needed. Feel free to close if you'd prefer to keep one button. 🙂